### PR TITLE
Fixed errors

### DIFF
--- a/scripts/rnn.lua
+++ b/scripts/rnn.lua
@@ -14,7 +14,7 @@ function RNN:__init(params)
 	self.use_dropout = params['dropout']
 	self.max_grad = params['maxGrad']
 	self.dropoutPred = params['dropoutPred']
-	self.max_steps = params['max_steps']
+	self.max_steps = params['maxSteps']
 
 	self.n_input = self.n_questions * 2
 	self.compressedSensing = params['compressedSensing']
@@ -86,7 +86,7 @@ function RNN:zeroGrad(n_steps)
 	self.layer:zeroGradParameters()
 end
 
-function RNN:update(rate)
+function RNN:update(n_steps, rate)
 	self.start:updateParameters(rate)
 	self.layer:updateParameters(rate)
 end

--- a/scripts/rnn.lua
+++ b/scripts/rnn.lua
@@ -14,7 +14,7 @@ function RNN:__init(params)
 	self.use_dropout = params['dropout']
 	self.max_grad = params['maxGrad']
 	self.dropoutPred = params['dropoutPred']
-	self.max_steps = params['maxSteps']
+	self.max_steps = params['max_steps']
 
 	self.n_input = self.n_questions * 2
 	self.compressedSensing = params['compressedSensing']
@@ -86,7 +86,7 @@ function RNN:zeroGrad(n_steps)
 	self.layer:zeroGradParameters()
 end
 
-function RNN:update(n_steps, rate)
+function RNN:update(rate)
 	self.start:updateParameters(rate)
 	self.layer:updateParameters(rate)
 end

--- a/scripts/trainSynthetic.lua
+++ b/scripts/trainSynthetic.lua
@@ -29,6 +29,7 @@ function run()
 	}
 
 	local name = "result_c" .. CONCEPT_NUM .. "_v" .. VERSION
+	lfs.mkdir(paths.dirname(outputRoot))
 	lfs.mkdir(outputRoot)
 	lfs.mkdir(outputRoot .. "models")
 

--- a/scripts/trainSynthetic.lua
+++ b/scripts/trainSynthetic.lua
@@ -24,7 +24,7 @@ function run()
 		n_hidden = n_hidden,
 		n_questions = data.n_questions,
 		max_grad = 100,
-		max_steps = data.n_questions,
+		maxSteps = data.n_questions,
 		--modelDir = outputRoot .. '/models/result_c5_v0_98'
 	}
 
@@ -73,7 +73,7 @@ function trainMiniBatch(rnn, data, init_rate, decay_rate, mini_batch_size, blob_
 			miniErr = miniErr + err
 			miniTests = miniTests + tests
 			if done % mini_batch_size == 0 then
-				rnn:update(rate)
+				rnn:update(nil, rate)
 				rnn:zeroGrad()
 				print(i/#miniBatches, sumErr/numTests)
 				miniErr = 0


### PR DESCRIPTION
Should be able to execute without errors now.
The last fix was due to `lfs.mkdir` not supporting `-p` option as in normal cmd line interface.
